### PR TITLE
Add Support for <= 19 (kitkat)

### DIFF
--- a/app/src/main/java/co/com/parsoniisolutions/custombottomsheetbehavior/lib/BackdropBottomSheetBehavior.java
+++ b/app/src/main/java/co/com/parsoniisolutions/custombottomsheetbehavior/lib/BackdropBottomSheetBehavior.java
@@ -47,6 +47,10 @@ public class BackdropBottomSheetBehavior<V extends View> extends CoordinatorLayo
         mCollapsedY = dependency.getHeight() - (2 * mPeakHeight);
         mAnchorPointY = child.getHeight();
         mCurrentChildY = (int) dependency.getY();
+        //TODO
+        if(mCurrentChildY == mAnchorPointY || mCurrentChildY == mAnchorPointY-1 ||mCurrentChildY == mAnchorPointY+1)
+            child.setY(0);
+        else child.setY(mCurrentChildY);
         mInit = true;
     }
 

--- a/app/src/main/java/co/com/parsoniisolutions/custombottomsheetbehavior/lib/ScrollingAppBarLayoutBehavior.java
+++ b/app/src/main/java/co/com/parsoniisolutions/custombottomsheetbehavior/lib/ScrollingAppBarLayoutBehavior.java
@@ -15,10 +15,8 @@ import android.support.v4.content.ContextCompat;
 import android.support.v4.widget.NestedScrollView;
 import android.util.AttributeSet;
 import android.view.View;
-import android.view.ViewGroup;
 import android.view.Window;
 import android.view.WindowManager;
-import android.widget.FrameLayout;
 
 import co.com.parsoniisolutions.custombottomsheetbehavior.R;
 
@@ -34,7 +32,6 @@ public class ScrollingAppBarLayoutBehavior extends AppBarLayout.ScrollingViewBeh
     private boolean mVisible = true;
 
     private int mPeekHeight;
-    private View mStatusBarBackground;
 
     private ValueAnimator mAppBarYValueAnimator;
 
@@ -133,40 +130,17 @@ public class ScrollingAppBarLayoutBehavior extends AppBarLayout.ScrollingViewBeh
     }
 
     private void setStatusBarBackgroundVisible(boolean visible){
-        if(visible){
-            if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP){
-
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP){
+            if(visible){
                 Window window = ((Activity)mContext).getWindow();
                 window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
                 window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
                 window.setStatusBarColor(ContextCompat.getColor(mContext,R.color.colorPrimaryDark));
-                mStatusBarBackground = new View(mContext);
-
-            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                if(mStatusBarBackground == null){
-                    Window w = ((Activity)mContext).getWindow();
-                    w.setFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS, WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
-                    //status bar height
-                    int statusBarHeight = getStatusBarHeight();
-                    mStatusBarBackground = new View(mContext);
-                    mStatusBarBackground.setLayoutParams(new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
-                    mStatusBarBackground.getLayoutParams().height = statusBarHeight;
-                    ((ViewGroup) w.getDecorView()).addView(mStatusBarBackground);
-                    mStatusBarBackground.setBackgroundColor(ContextCompat.getColor(mContext,R.color.colorPrimary));
-                }
-            }
-        }else {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP){
+            }else {
                 Window window = ((Activity)mContext).getWindow();
                 window.clearFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
                 window.addFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
                 window.setStatusBarColor(ContextCompat.getColor(mContext,android.R.color.transparent));
-            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT){
-                if(mStatusBarBackground != null){
-                    Window w = ((Activity)mContext).getWindow();
-                    ((ViewGroup) w.getDecorView()).removeView(mStatusBarBackground);
-                    mStatusBarBackground = null;
-                }
             }
         }
     }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -28,8 +28,7 @@
         android:layout_height="wrap_content"
         android:theme="@style/AppTheme.AppBarOverlay"
         app:behavior_scrolling_appbar_peek_height="@dimen/bottom_sheet_peek_height"
-        app:layout_behavior="@string/ScrollingAppBarLayoutBehavior"
-        android:fitsSystemWindows="true">
+        app:layout_behavior="@string/ScrollingAppBarLayoutBehavior">
 
         <android.support.v7.widget.Toolbar
             android:id="@+id/toolbar"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,7 +7,6 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
-
     tools:context=".sample.MainActivity">
 
     <FrameLayout
@@ -29,7 +28,8 @@
         android:layout_height="wrap_content"
         android:theme="@style/AppTheme.AppBarOverlay"
         app:behavior_scrolling_appbar_peek_height="@dimen/bottom_sheet_peek_height"
-        app:layout_behavior="@string/ScrollingAppBarLayoutBehavior">
+        app:layout_behavior="@string/ScrollingAppBarLayoutBehavior"
+        android:fitsSystemWindows="true">
 
         <android.support.v7.widget.Toolbar
             android:id="@+id/toolbar"
@@ -37,6 +37,43 @@
             android:layout_height="?attr/actionBarSize"
             app:popupTheme="@style/AppTheme.PopupOverlay"/>
     </android.support.design.widget.AppBarLayout>
+
+    <android.support.v4.view.ViewPager
+        android:id="@+id/pager"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/anchor_point"
+        app:behavior_backdrop_peekHeight="@dimen/bottom_sheet_peek_height"
+        android:background="@color/colorAccent"
+        app:layout_behavior="@string/BackDropBottomSheetBehavior"
+        android:fitsSystemWindows="true">
+    </android.support.v4.view.ViewPager>
+
+    <android.support.v4.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        app:behavior_peekHeight="@dimen/bottom_sheet_peek_height"
+        android:id="@+id/bottom_sheet"
+        app:layout_behavior="@string/BottomSheetBehaviorGoogleMapsLike"
+        app:anchorPoint="@dimen/anchor_point"
+        android:fitsSystemWindows="true">
+
+        <include
+            layout="@layout/bottom_sheet_content"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:fitsSystemWindows="true"/>
+    </android.support.v4.widget.NestedScrollView>
+
+    <android.support.design.widget.FloatingActionButton
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        app:layout_anchor="@id/bottom_sheet"
+        app:layout_anchorGravity="top|right|end"
+        android:src="@drawable/ic_action_go"
+        android:layout_margin="@dimen/fab_margin"
+        app:layout_behavior="@string/ScrollAwareFABBehavior"
+        android:clickable="true"/>
 
     <android.support.design.widget.AppBarLayout
         android:id="@+id/merged_appbarlayout"
@@ -65,40 +102,4 @@
                 app:navigationIcon="@drawable/ic_close_white_24dp"/>
         </FrameLayout>
     </android.support.design.widget.AppBarLayout>
-
-    <android.support.v4.view.ViewPager
-        android:id="@+id/pager"
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/anchor_point"
-        app:behavior_backdrop_peekHeight="@dimen/bottom_sheet_peek_height"
-        android:background="@color/colorAccent"
-        app:layout_behavior="@string/BackDropBottomSheetBehavior">
-    </android.support.v4.view.ViewPager>
-
-    <android.support.v4.widget.NestedScrollView
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical"
-        app:behavior_peekHeight="@dimen/bottom_sheet_peek_height"
-        android:id="@+id/bottom_sheet"
-        app:layout_behavior="@string/BottomSheetBehaviorGoogleMapsLike"
-        app:anchorPoint="@dimen/anchor_point">
-
-        <include
-            layout="@layout/bottom_sheet_content"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"/>
-
-    </android.support.v4.widget.NestedScrollView>
-
-
-    <android.support.design.widget.FloatingActionButton
-        android:layout_height="wrap_content"
-        android:layout_width="wrap_content"
-        app:layout_anchor="@id/bottom_sheet"
-        app:layout_anchorGravity="top|right|end"
-        android:src="@drawable/ic_action_go"
-        android:layout_margin="@dimen/fab_margin"
-        app:layout_behavior="@string/ScrollAwareFABBehavior"
-        android:clickable="true"/>
 </android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/bottom_sheet_content.xml
+++ b/app/src/main/res/layout/bottom_sheet_content.xml
@@ -10,12 +10,12 @@
 
     <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="80dp"
+        android:layout_height="@dimen/bottom_sheet_peek_height"
         android:background="@color/colorPrimary"
-        android:paddingTop="14dp"
-        android:paddingStart="12dp"
-        android:paddingEnd="12dp"
-        android:paddingBottom="12dp">
+        android:paddingTop="8dp"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:paddingBottom="8dp">
 
         <LinearLayout
             android:layout_width="wrap_content"

--- a/app/src/main/res/values-land-v19/dimens.xml
+++ b/app/src/main/res/values-land-v19/dimens.xml
@@ -1,0 +1,3 @@
+<resources>
+    <dimen name="anchor_point">150dp</dimen>
+</resources>

--- a/app/src/main/res/values-v19/dimens.xml
+++ b/app/src/main/res/values-v19/dimens.xml
@@ -1,0 +1,3 @@
+<resources>
+    <dimen name="bottom_sheet_peek_height">64dp</dimen>
+</resources>


### PR DESCRIPTION
We don't use the the status bar size on kitkat devices. It's possible but it seem some flag on the windows makes the NestedScrollView crazy. In addition, the google map experience is different under kitkat (at least in the emulator). I don't have much time to investigate now about that.
Otherwise, we seems to be pretty much done. There is probably some missing saved states (For example I didn't touch at all to the fab behavior and it seems to not saving its state at all). I'll finish it tomorrow. Let me know if you have any issues or questions. 
