### PR TITLE
Added ignoring of collapse state

### DIFF
--- a/app/src/main/java/com/mahc/custombottomsheet/MainActivity.java
+++ b/app/src/main/java/com/mahc/custombottomsheet/MainActivity.java
@@ -85,7 +85,7 @@ public class MainActivity extends AppCompatActivity {
         mergedAppBarLayoutBehavior.setNavigationOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                behavior.setState(BottomSheetBehaviorGoogleMapsLike.STATE_COLLAPSED);
+                behavior.setState(BottomSheetBehaviorGoogleMapsLike.STATE_ANCHOR_POINT);
             }
         });
 
@@ -95,5 +95,6 @@ public class MainActivity extends AppCompatActivity {
         viewPager.setAdapter(adapter);
 
         behavior.setState(BottomSheetBehaviorGoogleMapsLike.STATE_ANCHOR_POINT);
+        //behavior.setCollapsible(false);
     }
 }

--- a/googlemaps-like/src/main/java/com/mahc/custombottomsheetbehavior/BottomSheetBehaviorGoogleMapsLike.java
+++ b/googlemaps-like/src/main/java/com/mahc/custombottomsheetbehavior/BottomSheetBehaviorGoogleMapsLike.java
@@ -101,6 +101,8 @@ public class BottomSheetBehaviorGoogleMapsLike<V extends View> extends Coordinat
 
     private boolean mHideable;
 
+    private int[] mIgnoreStates;
+
     @State
     private int mState = STATE_ANCHOR_POINT;
     @State
@@ -144,6 +146,7 @@ public class BottomSheetBehaviorGoogleMapsLike<V extends View> extends Coordinat
         setPeekHeight(a.getDimensionPixelSize(
                 android.support.design.R.styleable.BottomSheetBehavior_Layout_behavior_peekHeight, 0));
         setHideable(a.getBoolean(android.support.design.R.styleable.BottomSheetBehavior_Layout_behavior_hideable, false));
+        setIgnoreStates(null);
         a.recycle();
 
         /**
@@ -525,6 +528,26 @@ public class BottomSheetBehaviorGoogleMapsLike<V extends View> extends Coordinat
      */
     public boolean isHideable() {
         return mHideable;
+    }
+
+    /**
+     * Sets whether some states should be skipped.
+     *
+     * @param hideable {@code true} to make this bottom sheet hideable.
+     * @attr ref android.support.design.R.styleable#BottomSheetBehavior_Params_behavior_hideable
+     */
+    public void setIgnoreStates(int[] ignoreStates) {
+        mIgnoreStates = ignoreStates;
+    }
+
+    /**
+     * Gets whether some states should be skipped.
+     *
+     * @return {@code true} if this bottom sheet can hide.
+     * @attr ref android.support.design.R.styleable#BottomSheetBehavior_Params_behavior_hideable
+     */
+    public int[] getIgnoreStates() {
+        return mIgnoreStates;
     }
 
     /**


### PR DESCRIPTION
Hi,

I finally added a boolean attribute (mCollapsible) that can be set to true/false.
Default is true. If set to false, it will ignore collapsible state and not allow to scroll below anchor view.

Please have a look into it and give feedback or merge.

The only misbehavior I recognized and could not solve is, if you scroll on the map up and down there is sometimes a small offset on top of a view pixel. I think thats a minor issue and maybe you know why this happens. Other than that I think it is working great.

Regards,
Manuel