### PR TITLE
Fix for issue #43 "mLastStableState was not set on setState"

### DIFF
--- a/googlemaps-like/src/main/java/com/mahc/custombottomsheetbehavior/BottomSheetBehaviorGoogleMapsLike.java
+++ b/googlemaps-like/src/main/java/com/mahc/custombottomsheetbehavior/BottomSheetBehaviorGoogleMapsLike.java
@@ -588,19 +588,17 @@ public class BottomSheetBehaviorGoogleMapsLike<V extends View> extends Coordinat
         if ( state == mState ) {
             return;
         }
-        if ( mViewRef == null ) {
-            // The view is not laid out yet; modify mState and let onLayoutChild handle it later
-            /**
-             * New behavior (added: state == STATE_ANCHOR_POINT ||)
-             */
-            if ( state == STATE_COLLAPSED || state == STATE_EXPANDED || state == STATE_ANCHOR_POINT ||
-                    (mHideable && state == STATE_HIDDEN)) {
-                mState = state;
-                mLastStableState = state;
-            }
-            return;
+
+        /**
+         * New behavior (added: state == STATE_ANCHOR_POINT ||)
+         */
+        if ( state == STATE_COLLAPSED || state == STATE_EXPANDED || state == STATE_ANCHOR_POINT ||
+                (mHideable && state == STATE_HIDDEN)) {
+            mState = state;
+            mLastStableState = state;
         }
-        V child = mViewRef.get();
+
+        V child = mViewRef == null ? null : mViewRef.get();
         if (child == null) {
             return;
         }


### PR DESCRIPTION
This is a proposal for fixing issue https://github.com/miguelhincapie/CustomBottomSheetBehavior/issues/43. It ensures that the variables `mState` and `mLastStableState` are always updated when calling the `setState`-methods.